### PR TITLE
feat: control button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 dist-ssr
 *.local
 vue-zoomable-*.tgz
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All props other than `selector` are observable and can be changed after initiali
 | initialPanX          | number  | 0       | Initial pan along x-axis                                                        |
 | initialPanY          | number  | 0       | Initial pan along y-axis                                                        |
 | enableControllButton | boolean    | false   | Defines, if the controll buttons will be enabled.                               |
-| buttonPanStep        | number  | 0.1     | Step size for pan on controll buttons                                           |
+| buttonPanStep        | number  | 15     | Step size for pan on controll buttons                                           |
 | buttonZoomStep       | number  | 0.1     | Step size for pan on controll buttons                                           |
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ Contributions are most welcome. Please follow the below steps for any contributi
 - If you are resolving an issue, please add `fix: #<issue number> <short message>` in your PR title (e.g.fix: #3899 update entities encoding/decoding).
 - Provide a description of the bug in your PR and/or link to the issue.
 
+### Setup
+
+The setup is pretty easy. You need to have `npm` installed.
+
+```sh
+# install the dependencies
+npm install --dev
+
+# start the dev thingie
+npm run dev
+```
+
 ### Where should I start?
 
 A good way to start is to find an issue labeled as bug, help wanted or feature request and suggest your approach in comments.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ All props other than `selector` are observable and can be changed after initiali
 | initialZoom          | number  | 0.5     | Initial zoom value                                                              |
 | initialPanX          | number  | 0       | Initial pan along x-axis                                                        |
 | initialPanY          | number  | 0       | Initial pan along y-axis                                                        |
-| enableControllButton | bool    | false   | Defines, if the controll buttons will be enabled.                               |
+| enableControllButton | boolean    | false   | Defines, if the controll buttons will be enabled.                               |
 | buttonPanStep        | number  | 0.1     | Step size for pan on controll buttons                                           |
 | buttonZoomStep       | number  | 0.1     | Step size for pan on controll buttons                                           |
 

--- a/README.md
+++ b/README.md
@@ -39,22 +39,25 @@ import "vue-zoomable/dist/style.css";
 
 All props other than `selector` are observable and can be changed after initialization.
 
-| Name             | type    | default | Description                                                                     |
-| ---------------- | ------- | ------- | ------------------------------------------------------------------------------- |
-| selector         | string  | `* > *` | Root element to apply transform on. Preferrably an `id` on `<div>` or `<g>` tag |
-| maxZoom          | number  | 3       | Maximum allowed zoom                                                            |
-| minZoom          | number  | 0.5     | Minimum allowed zoom                                                            |
-| dblClickZoomStep | number  | 0.4     | Step size for zoom on double click                                              |
-| wheelZoomStep    | number  | 0.05    | Step size for zoom on wheel                                                     |
-| panEnabled       | boolean | true    | Enable panning                                                                  |
-| zoomEnabled      | boolean | true    | Enable zoom                                                                     |
-| mouseEnabled     | boolean | true    | Enable mouse events                                                             |
-| touchEnabled     | boolean | true    | Enable touch events                                                             |
-| dblClickEnabled  | boolean | true    | Zoom on double click enabled                                                    |
-| wheelEnabled     | boolean | true    | Zoom on mouse enabled                                                           |
-| initialZoom      | number  | 0.5     | Initial zoom value                                                              |
-| initialPanX      | number  | 0       | Initial pan along x-axis                                                        |
-| initialPanY      | number  | 0       | Initial pan along y-axis                                                        |
+| Name                 | type    | default | Description                                                                     |
+| -------------------- | ------- | ------- | ------------------------------------------------------------------------------- |
+| selector             | string  | `* > *` | Root element to apply transform on. Preferrably an `id` on `<div>` or `<g>` tag |
+| maxZoom              | number  | 3       | Maximum allowed zoom                                                            |
+| minZoom              | number  | 0.5     | Minimum allowed zoom                                                            |
+| dblClickZoomStep     | number  | 0.4     | Step size for zoom on double click                                              |
+| wheelZoomStep        | number  | 0.05    | Step size for zoom on wheel                                                     |
+| panEnabled           | boolean | true    | Enable panning                                                                  |
+| zoomEnabled          | boolean | true    | Enable zoom                                                                     |
+| mouseEnabled         | boolean | true    | Enable mouse events                                                             |
+| touchEnabled         | boolean | true    | Enable touch events                                                             |
+| dblClickEnabled      | boolean | true    | Zoom on double click enabled                                                    |
+| wheelEnabled         | boolean | true    | Zoom on mouse enabled                                                           |
+| initialZoom          | number  | 0.5     | Initial zoom value                                                              |
+| initialPanX          | number  | 0       | Initial pan along x-axis                                                        |
+| initialPanY          | number  | 0       | Initial pan along y-axis                                                        |
+| enableControllButton | bool    | false   | Defines, if the controll buttons will be enabled.                               |
+| buttonPanStep        | number  | 0.1     | Step size for pan on controll buttons                                           |
+| buttonZoomStep       | number  | 0.1     | Step size for pan on controll buttons                                           |
 
 ### Events
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue-zoomable",
-  "version": "1.0.0-beta",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-zoomable",
-      "version": "1.0.0-beta",
+      "version": "1.0.9",
       "devDependencies": {
         "@types/node": "^17.0.17",
         "@vitejs/plugin-vue": "^2.0.0",

--- a/src/components/ControllButtons.vue
+++ b/src/components/ControllButtons.vue
@@ -1,53 +1,66 @@
 <template>
-    <div class="controll__buttons">
+    <div class="controll__buttons" @dblclick.stop="" @mousedown.stop="">
         <ul class="controll">
             <li class="controll__item controll__item--circle">
                 <ul class="controll__pan controll__item--circle__inner">
-                    <li class="controll__pan__up controll__item--circle__inner__up"><a><svg xmlns="http://www.w3.org/2000/svg"
-                                width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                    <li class="controll__pan__up controll__item--circle__inner__up">
+                        <a @click="emit('button-pan', $event)" data-direction="up">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                                 class="feather feather-chevron-up">
                                 <polyline points="18 15 12 9 6 15"></polyline>
-                            </svg></a></li>
-                    <li class="controll__pan__right controll__item--circle__inner__right"><a><svg
-                                xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                            </svg>
+                        </a>
+                    </li>
+                    <li class="controll__pan__right controll__item--circle__inner__right">
+                        <a @click="emit('button-pan', $event)" data-direction="right">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
                                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                                 class="feather feather-chevron-right">
                                 <polyline points="9 18 15 12 9 6"></polyline>
-                            </svg></a></li>
-                    <li class="controll__pan__down controll__item--circle__inner__down"><a><svg xmlns="http://www.w3.org/2000/svg"
-                                width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            </svg>
+                        </a>
+                    </li>
+                    <li class="controll__pan__down controll__item--circle__inner__down">
+                        <a @click="emit('button-pan', $event)" data-direction="down">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                                 class="feather feather-chevron-down">
                                 <polyline points="6 9 12 15 18 9"></polyline>
-                            </svg></a></li>
-                    <li class="controll__pan__left controll__item--circle__inner__left"><a><svg xmlns="http://www.w3.org/2000/svg"
-                                width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            </svg></a>
+                    </li>
+                    <li class="controll__pan__left controll__item--circle__inner__left">
+                        <a @click="emit('button-pan', $event)" data-direction="left">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                                 class="feather feather-chevron-left">
                                 <polyline points="15 18 9 12 15 6"></polyline>
-                            </svg></a></li>
+                            </svg>
+                        </a>
+                    </li>
                 </ul>
             </li>
-            <li class="controll__home controll__item controll__item--list-item"><a><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                        viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                        stroke-linejoin="round" class="feather feather-minimize-2">
+            <li class="controll__home controll__item controll__item--list-item"><a><svg xmlns="http://www.w3.org/2000/svg"
+                        width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round" class="feather feather-minimize-2">
                         <polyline points="4 14 10 14 10 20"></polyline>
                         <polyline points="20 10 14 10 14 4"></polyline>
                         <line x1="14" y1="10" x2="21" y2="3"></line>
                         <line x1="3" y1="21" x2="10" y2="14"></line>
                     </svg></a></li>
-            <li class="controll__zoom-in controll__item controll__item--list-item"><a><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                        viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                        stroke-linejoin="round" class="feather feather-zoom-in">
+            <li class="controll__zoom-in controll__item controll__item--list-item"><a><svg
+                        xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        class="feather feather-zoom-in">
                         <circle cx="11" cy="11" r="8"></circle>
                         <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
                         <line x1="11" y1="8" x2="11" y2="14"></line>
                         <line x1="8" y1="11" x2="14" y2="11"></line>
                     </svg></a></li>
-            <li class="controll__zoom-in controll__item controll__item--list-item"><a><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                        viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                        stroke-linejoin="round" class="feather feather-zoom-out">
+            <li class="controll__zoom-in controll__item controll__item--list-item"><a><svg
+                        xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        class="feather feather-zoom-out">
                         <circle cx="11" cy="11" r="8"></circle>
                         <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
                         <line x1="8" y1="11" x2="14" y2="11"></line>
@@ -57,29 +70,7 @@
 </template>
 
 <script setup lang="ts">
-let emit = defineEmits(["panned", "zoom"]);
-let props = defineProps({
-    initialPanX: {
-        type: Number,
-        default: 0
-    },
-    initialPanY: {
-        type: Number,
-        default: 0
-    },
-    initialZoom: {
-        type: Number,
-        default: 0.5
-    },
-    buttonPanStep: {
-        type: Number,
-        default: 0.1,
-    },
-    buttonZoomStep: {
-        type: Number,
-        default: 0.1,
-    }
-});
+const emit = defineEmits(["button-pan", "button-zoom", "button-home"]);
 </script>
 
 <style scoped>

--- a/src/components/ControllButtons.vue
+++ b/src/components/ControllButtons.vue
@@ -1,0 +1,178 @@
+<template>
+    <div class="controll__buttons">
+        <ul class="controll">
+            <li class="controll__item controll__item--circle">
+                <ul class="controll__pan controll__item--circle__inner">
+                    <li class="controll__pan__up controll__item--circle__inner__up"><a><svg xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                class="feather feather-chevron-up">
+                                <polyline points="18 15 12 9 6 15"></polyline>
+                            </svg></a></li>
+                    <li class="controll__pan__right controll__item--circle__inner__right"><a><svg
+                                xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                class="feather feather-chevron-right">
+                                <polyline points="9 18 15 12 9 6"></polyline>
+                            </svg></a></li>
+                    <li class="controll__pan__down controll__item--circle__inner__down"><a><svg xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                class="feather feather-chevron-down">
+                                <polyline points="6 9 12 15 18 9"></polyline>
+                            </svg></a></li>
+                    <li class="controll__pan__left controll__item--circle__inner__left"><a><svg xmlns="http://www.w3.org/2000/svg"
+                                width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                class="feather feather-chevron-left">
+                                <polyline points="15 18 9 12 15 6"></polyline>
+                            </svg></a></li>
+                </ul>
+            </li>
+            <li class="controll__home controll__item controll__item--list-item"><a><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                        viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                        stroke-linejoin="round" class="feather feather-minimize-2">
+                        <polyline points="4 14 10 14 10 20"></polyline>
+                        <polyline points="20 10 14 10 14 4"></polyline>
+                        <line x1="14" y1="10" x2="21" y2="3"></line>
+                        <line x1="3" y1="21" x2="10" y2="14"></line>
+                    </svg></a></li>
+            <li class="controll__zoom-in controll__item controll__item--list-item"><a><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                        viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                        stroke-linejoin="round" class="feather feather-zoom-in">
+                        <circle cx="11" cy="11" r="8"></circle>
+                        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                        <line x1="11" y1="8" x2="11" y2="14"></line>
+                        <line x1="8" y1="11" x2="14" y2="11"></line>
+                    </svg></a></li>
+            <li class="controll__zoom-in controll__item controll__item--list-item"><a><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                        viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                        stroke-linejoin="round" class="feather feather-zoom-out">
+                        <circle cx="11" cy="11" r="8"></circle>
+                        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                        <line x1="8" y1="11" x2="14" y2="11"></line>
+                    </svg></a></li>
+        </ul>
+    </div>
+</template>
+
+<script setup lang="ts">
+let emit = defineEmits(["panned", "zoom"]);
+let props = defineProps({
+    initialPanX: {
+        type: Number,
+        default: 0
+    },
+    initialPanY: {
+        type: Number,
+        default: 0
+    },
+    initialZoom: {
+        type: Number,
+        default: 0.5
+    },
+    buttonPanStep: {
+        type: Number,
+        default: 0.1,
+    },
+    buttonZoomStep: {
+        type: Number,
+        default: 0.1,
+    }
+});
+</script>
+
+<style scoped>
+ul {
+    list-style: none;
+    padding: 0;
+}
+
+a {
+    cursor: pointer;
+}
+
+
+.controll__buttons {
+    position: absolute;
+
+    bottom: 32px;
+    right: 32px;
+
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    background-color: white;
+    padding-top: 32px;
+}
+
+.controll {
+    margin: 0;
+
+    box-shadow: 0 5px 25px rgba(50, 50, 93, 0.05), 0 5px 15px rgba(0, 0, 0, 0.05);
+    /* border: 1px solid #dee2e6; */
+}
+
+.controll .controll__item--circle {
+    position: relative;
+}
+
+.controll__item--circle .controll__item--circle__inner {
+    position: absolute;
+    display: block;
+
+    top: -74px;
+    left: 50%;
+    width: 74px;
+    height: 74px;
+
+    margin: 0;
+    border-radius: 50%;
+    transform: translateX(-50%);
+
+    background-color: white;
+    border: 1px solid #dee2e6;
+    box-shadow: 0 5px 25px rgba(50, 50, 93, 0.05), 0 5px 15px rgba(0, 0, 0, 0.05);
+}
+
+.controll__item--circle .controll__item--circle__inner li {
+    position: absolute;
+}
+
+.controll__item--circle .controll__item--circle__inner .controll__item--circle__inner__up {
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.controll__item--circle .controll__item--circle__inner .controll__item--circle__inner__right {
+    top: 50%;
+    right: 0;
+    transform: translateY(-50%);
+}
+
+.controll__item--circle .controll__item--circle__inner .controll__item--circle__inner__down {
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.controll__item--circle .controll__item--circle__inner .controll__item--circle__inner__left {
+    top: 50%;
+    left: 0;
+    transform: translateY(-50%);
+}
+
+.controll--item {
+    display: block;
+    line-height: 1;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.controll--item:last-child {
+    border-bottom: 0;
+}
+
+.controll__item--list-item {
+    padding: 12px;
+}
+</style>

--- a/src/components/ControllButtons.vue
+++ b/src/components/ControllButtons.vue
@@ -40,31 +40,41 @@
                     </li>
                 </ul>
             </li>
-            <li class="controll__home controll__item controll__item--list-item"><a><svg xmlns="http://www.w3.org/2000/svg"
-                        width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                        stroke-linecap="round" stroke-linejoin="round" class="feather feather-minimize-2">
+            <li class="controll__home controll__item controll__item--list-item">
+                <a @click="emit('button-home');">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        class="feather feather-minimize-2">
                         <polyline points="4 14 10 14 10 20"></polyline>
                         <polyline points="20 10 14 10 14 4"></polyline>
                         <line x1="14" y1="10" x2="21" y2="3"></line>
                         <line x1="3" y1="21" x2="10" y2="14"></line>
-                    </svg></a></li>
-            <li class="controll__zoom-in controll__item controll__item--list-item"><a><svg
-                        xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                    </svg>
+                </a>
+            </li>
+            <li class="controll__zoom-in controll__item controll__item--list-item">
+                <a @click="emit('button-zoom', $event);" data-direction="in">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                         class="feather feather-zoom-in">
                         <circle cx="11" cy="11" r="8"></circle>
                         <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
                         <line x1="11" y1="8" x2="11" y2="14"></line>
                         <line x1="8" y1="11" x2="14" y2="11"></line>
-                    </svg></a></li>
-            <li class="controll__zoom-in controll__item controll__item--list-item"><a><svg
-                        xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                    </svg>
+                </a>
+            </li>
+            <li class="controll__zoom-in controll__item controll__item--list-item">
+                <a @click="emit('button-zoom', $event);" data-direction="out">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                         class="feather feather-zoom-out">
                         <circle cx="11" cy="11" r="8"></circle>
                         <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
                         <line x1="8" y1="11" x2="14" y2="11"></line>
-                    </svg></a></li>
+                    </svg>
+                </a>
+            </li>
         </ul>
     </div>
 </template>

--- a/src/components/ControllButtons.vue
+++ b/src/components/ControllButtons.vue
@@ -91,7 +91,14 @@ ul {
 
 a {
     cursor: pointer;
+    color: #868e96;
+
+    transition: color .15s ease;
 }
+
+a:hover {
+    color: #555b61;;
+} 
 
 
 .controll__buttons {

--- a/src/components/VueZoomable.vue
+++ b/src/components/VueZoomable.vue
@@ -82,7 +82,7 @@ let props = defineProps({
     },
     buttonPanStep: {
         type: Number,
-        default: 10,
+        default: 15,
     },
     buttonZoomStep: {
         type: Number,

--- a/src/components/VueZoomable.vue
+++ b/src/components/VueZoomable.vue
@@ -4,7 +4,7 @@
         @dblclick="mouse.onDblClick" @touchstart="touch.onTouchStart" @wheel="wheel.onWheel">
         <slot />
 
-        <ControllButtons v-if="props.enableControllButton"></ControllButtons>
+        <ControllButtons v-if="props.enableControllButton" @button-home="button.onHome" @button-pan="button.onPan"  @button-zoom="button.onZoom"></ControllButtons>
     </div>
 </template>
 
@@ -14,6 +14,7 @@ import { onMounted, watch } from 'vue';
 import { useMouse } from "../composables/useMouse";
 import { useTouch } from "../composables/useTouch";
 import { useWheel } from "../composables/useWheel";
+import { useButtons } from '../composables/useButtons';
 
 import ControllButtons from './ControllButtons.vue';
 
@@ -81,13 +82,14 @@ let props = defineProps({
     },
     buttonPanStep: {
         type: Number,
-        default: 0.1,
+        default: 10,
     },
     buttonZoomStep: {
         type: Number,
         default: 0.1,
     }
 });
+
 let container = ref();
 let zoom = ref(props.minZoom);
 if ((props.initialZoom >= props.minZoom) && (props.initialZoom <= props.maxZoom)) {
@@ -126,6 +128,7 @@ onMounted(() => {
 let mouse = useMouse(props, emit, pan, zoom);
 let touch = useTouch(props, emit, pan, zoom);
 let wheel = useWheel(props, emit, pan, zoom);
+let button = useButtons(props, emit, pan, zoom);
 </script>
 
 <style module>

--- a/src/components/VueZoomable.vue
+++ b/src/components/VueZoomable.vue
@@ -1,23 +1,21 @@
 
 <template>
-    <div
-        ref="container"
-        class="container"
-        :class="$style.container"
-        @mousedown="mouse.onMouseDown"
-        @dblclick="mouse.onDblClick"
-        @touchstart="touch.onTouchStart"
-        @wheel="wheel.onWheel"
-    >
+    <div ref="container" class="container" :class="$style.container" @mousedown="mouse.onMouseDown"
+        @dblclick="mouse.onDblClick" @touchstart="touch.onTouchStart" @wheel="wheel.onWheel">
         <slot />
+
+        <ControllButtons v-if="props.enableControllButton"></ControllButtons>
     </div>
 </template>
+
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { onMounted, watch } from 'vue';
 import { useMouse } from "../composables/useMouse";
 import { useTouch } from "../composables/useTouch";
 import { useWheel } from "../composables/useWheel";
+
+import ControllButtons from './ControllButtons.vue';
 
 let emit = defineEmits(["panned", "zoom"]);
 let props = defineProps({
@@ -77,6 +75,18 @@ let props = defineProps({
         type: Boolean,
         default: true,
     },
+    enableControllButton: {
+        type: Boolean,
+        default: false,
+    },
+    buttonPanStep: {
+        type: Number,
+        default: 0.1,
+    },
+    buttonZoomStep: {
+        type: Number,
+        default: 0.1,
+    }
 });
 let container = ref();
 let zoom = ref(props.minZoom);
@@ -116,10 +126,12 @@ onMounted(() => {
 let mouse = useMouse(props, emit, pan, zoom);
 let touch = useTouch(props, emit, pan, zoom);
 let wheel = useWheel(props, emit, pan, zoom);
-
 </script>
+
 <style module>
 .container {
     overflow: hidden;
+
+    position: relative;
 }
 </style>

--- a/src/composables/useButtons.ts
+++ b/src/composables/useButtons.ts
@@ -1,0 +1,70 @@
+import { Ref } from "vue";
+
+export function useButtons(
+    props: any,
+    emit: any,
+    pan: Ref<{ x: number, y: number }>,
+    zoom: Ref<number>) {
+
+    interface PanDirection {
+        x: number;
+        y: number;
+    }
+
+    const panDirections: { [key: string]: PanDirection } = {
+        "up": { x: 0, y: -props.buttonPanStep },
+        "right": { x: props.buttonPanStep, y: 0 },
+        "down": { x: 0, y: props.buttonPanStep },
+        "left": { x: -props.buttonPanStep, y: 0 },
+    }
+
+    function onPan(ev: MouseEvent) {
+        const target = ev.currentTarget as HTMLAnchorElement;
+
+        if (!target) {
+            console.warn("The target of the event is null, which shouldn't be the case.");
+            return;
+        }
+
+        const directionString = target.getAttribute("data-direction");
+
+        if (directionString && !(directionString in panDirections)) {
+            console.error("The direction " + directionString + " doesn't exist, and this really should not happen.")
+            return;
+        }
+
+        if (!directionString) { return }
+        const direction = panDirections[directionString];
+
+        pan.value = {
+            x: pan.value.x + direction.x,
+            y: pan.value.y + direction.y,
+        }
+
+        let event: ZoomableEvent = {
+            zoom: zoom.value,
+            pan: {
+                x: pan.value.x,
+                y: pan.value.y,
+                deltaX: direction.x,
+                deltaY: direction.y
+            },
+            type: "controll_button",
+        }
+        emit("panned", event);
+    }
+
+    function onZoom(ev: MouseEvent) {
+
+    }
+
+    function onHome() {
+
+    }
+
+    return {
+        onPan,
+        onZoom,
+        onHome,
+    }
+}

--- a/src/composables/useButtons.ts
+++ b/src/composables/useButtons.ts
@@ -89,7 +89,11 @@ export function useButtons(
     }
 
     function onHome() {
-
+        zoom.value = props.initialZoom;
+        pan.value = {
+            x: props.initialPanX,
+            y: props.initialPanY,
+        }
     }
 
     return {

--- a/src/composables/useButtons.ts
+++ b/src/composables/useButtons.ts
@@ -6,6 +6,9 @@ export function useButtons(
     pan: Ref<{ x: number, y: number }>,
     zoom: Ref<number>) {
 
+
+    const eventType: string = "controll_button";
+
     interface PanDirection {
         x: number;
         y: number;
@@ -58,7 +61,7 @@ export function useButtons(
                 deltaX: direction.x,
                 deltaY: direction.y
             },
-            type: "controll_button",
+            type: eventType,
         }
         emit("panned", event);
     }
@@ -83,17 +86,44 @@ export function useButtons(
                 deltaX: 0,
                 deltaY: 0,
             },
-            type: "controll_button",
+            type: eventType,
         }
         emit("zoom", event);
     }
 
     function onHome() {
+        // reset zoom
         zoom.value = props.initialZoom;
+        emit("zoom", {
+            zoom: zoom.value,
+            pan: {
+                x: pan.value.x,
+                y: pan.value.y,
+                deltaX: 0,
+                deltaY: 0,
+            },
+            type: eventType,
+        })
+
+        // reset pan
+        let delta = {
+            x: props.initialPanX - pan.value.x,
+            y: props.initialPanY - pan.value.y,
+        }
         pan.value = {
             x: props.initialPanX,
             y: props.initialPanY,
         }
+        emit("panned", {
+            zoom: zoom.value,
+            pan: {
+                x: pan.value.x,
+                y: pan.value.y,
+                deltaX: delta.x,
+                deltaY: delta.y,
+            },
+            type: eventType,
+        })
     }
 
     return {

--- a/src/composables/useButtons.ts
+++ b/src/composables/useButtons.ts
@@ -18,22 +18,31 @@ export function useButtons(
         "left": { x: -props.buttonPanStep, y: 0 },
     }
 
-    function onPan(ev: MouseEvent) {
+    const zoomDirections: { [key: string]: number } = {
+        "in": props.buttonZoomStep,
+        "out": -props.buttonZoomStep
+    }
+
+    let directionFromEvent = function (ev: MouseEvent): string | null {
         const target = ev.currentTarget as HTMLAnchorElement;
 
         if (!target) {
             console.warn("The target of the event is null, which shouldn't be the case.");
-            return;
+            return null;
         }
 
         const directionString = target.getAttribute("data-direction");
+        return directionString;
+    }
 
-        if (directionString && !(directionString in panDirections)) {
-            console.error("The direction " + directionString + " doesn't exist, and this really should not happen.")
+    function onPan(ev: MouseEvent) {
+        const directionString = directionFromEvent(ev);
+        if (!directionString) { return }
+        if (!(directionString in panDirections)) {
+            console.error("The direction " + directionString + " doesn't exist, and this really should not happen.");
             return;
         }
 
-        if (!directionString) { return }
         const direction = panDirections[directionString];
 
         pan.value = {
@@ -55,7 +64,28 @@ export function useButtons(
     }
 
     function onZoom(ev: MouseEvent) {
+        const directionString = directionFromEvent(ev);
+        if (!directionString) { return }
+        if (!(directionString in zoomDirections)) {
+            console.error("The direction " + directionString + " doesn't exist, and this really should not happen.")
+            return;
+        }
 
+        const direction = zoomDirections[directionString];
+
+        zoom.value = zoom.value + direction;
+
+        let event: ZoomableEvent = {
+            zoom: zoom.value,
+            pan: {
+                x: pan.value.x,
+                y: pan.value.y,
+                deltaX: 0,
+                deltaY: 0,
+            },
+            type: "controll_button",
+        }
+        emit("zoom", event);
     }
 
     function onHome() {

--- a/src/composables/useButtons.ts
+++ b/src/composables/useButtons.ts
@@ -15,10 +15,10 @@ export function useButtons(
     }
 
     const panDirections: { [key: string]: PanDirection } = {
-        "up": { x: 0, y: -props.buttonPanStep },
-        "right": { x: props.buttonPanStep, y: 0 },
-        "down": { x: 0, y: props.buttonPanStep },
-        "left": { x: -props.buttonPanStep, y: 0 },
+        "up": { x: 0, y: props.buttonPanStep },
+        "right": { x: -props.buttonPanStep, y: 0 },
+        "down": { x: 0, y: -props.buttonPanStep },
+        "left": { x: props.buttonPanStep, y: 0 },
     }
 
     const zoomDirections: { [key: string]: number } = {

--- a/src/composables/useMouse.ts
+++ b/src/composables/useMouse.ts
@@ -28,6 +28,7 @@ export function useMouse(
             x: ev.clientX - dragLoc.x,
             y: ev.clientY - dragLoc.y,
         }
+        
         pan.value = {
             x: pan.value.x + delta.x,
             y: pan.value.y + delta.y,

--- a/src/examples/div_example.vue
+++ b/src/examples/div_example.vue
@@ -7,6 +7,7 @@
     <input type="checkbox" v-model="touchEnabled" />touchEnabled
     <input type="checkbox" v-model="mouseWheelZoomEnabled" />wheelEnabled
     <input type="checkbox" v-model="visible" />Slot Content
+    <input type="checkbox" v-model="enableControllButton" />Controll Button Enabled
   </form>
 
   <VueZoomable
@@ -21,6 +22,7 @@
     :maxZoom="2"
     :dblClickZoomStep="0.4"
     :wheelZoomStep="0.01"
+    :enableControllButton="enableControllButton"
     @zoom="onZoom"
     @panned="onPan"
   >
@@ -47,6 +49,7 @@ let dbClickEnabled = ref(true);
 let touchEnabled = ref(true);
 let mouseWheelZoomEnabled = ref(true);
 let visible = ref(true);
+let enableControllButton = ref(true);
 
 let onPan = (ev: any) => {
   console.log(ev);

--- a/src/examples/svg_example.vue
+++ b/src/examples/svg_example.vue
@@ -8,6 +8,7 @@
     <input type="checkbox" v-model="touchEnabled" />touchEnabled
     <input type="checkbox" v-model="mouseWheelZoomEnabled" />wheelEnabled
     <input type="checkbox" v-model="visible" />Slot Content
+    <input type="checkbox" v-model="enableControllButton" />Controll Button Enabled
   </form>
   <!-- :eventsListenerElement="listener" -->
 
@@ -27,6 +28,7 @@
     :maxZoom="2"
     :dblClickZoomStep="0.4"
     :wheelZoomStep="0.01"
+    :enableControllButton="enableControllButton"
     @zoom="onZoom"
     @panned="onPan"
   >
@@ -48,6 +50,7 @@ let dbClickEnabled = ref(true);
 let touchEnabled = ref(true);
 let mouseWheelZoomEnabled = ref(true);
 let visible = ref(true);
+let enableControllButton = ref(true);
 
 let onPan = (ev: any) => {
   console.log(ev);


### PR DESCRIPTION
I added control buttons #8. _(see screenshot)_

![control button](https://github.com/HassaanAkbar/vue-zoomable/assets/74311245/82c1cb6e-7eab-4b56-ac73-b01c614ee149)

They are disabled by default, to not interfere with the people, that already use this library. I don't want them suddenly having control buttons without wanting them.

I would greatly appreciate it if you'd upload it today to npm, such that we can deploy our feature tomorrow. If you can't, don't worry though <3333   
Thank you very very much for your great work!

# Which props I added

You can enable them, by setting `enableControllButton` to `true`. I also added two more props to control the behavior of the control button better.

| Name                 | type    | default | Description                                                                     |
| -------------------- | ------- | ------- | ------------------------------------------------------------------------------- |
| enableControllButton | boolean    | false   | Defines, if the controll buttons will be enabled.                               |
| buttonPanStep        | number  | 15     | Step size for pan on controll buttons                                           |
| buttonZoomStep       | number  | 0.1     | Step size for pan on controll buttons                                           |

I don't have a feature to only enable the pan, zoom or home button, either all or none. But if you want this feature, it shouldn't be too hard to implement for you.

# Functionality

## Pan Buttons

They do the pan thingy.

## Home Button

Sets the pan and zoom to the initialZoom and initialPan.

## Zoom Buttons

They do the zoom thingy.

[This is how those descriptions felt like: ](https://www.reddit.com/r/ProgrammerHumor/comments/i4v6b2/comments/)

![image](https://github.com/HassaanAkbar/vue-zoomable/assets/74311245/f99b9350-9dd1-4b6a-8a0c-8876b264cd4d)
